### PR TITLE
Add dynamic schema-based register reader classes

### DIFF
--- a/harp/io.py
+++ b/harp/io.py
@@ -1,5 +1,5 @@
 from os import PathLike
-from typing import Any, Optional, Union
+from typing import Any, BinaryIO, Optional, Union
 from pandas._typing import Axes
 import numpy as np
 import pandas as pd
@@ -19,7 +19,7 @@ payloadtypes = {
 
 
 def read(
-    file: Union[str, bytes, PathLike[Any], np._IOProtocol],
+    file: Union[str, bytes, PathLike[Any], BinaryIO],
     columns: Optional[Axes] = None,
 ):
     """

--- a/harp/io.py
+++ b/harp/io.py
@@ -4,7 +4,7 @@ from pandas._typing import Axes
 import numpy as np
 import pandas as pd
 
-_SECONDS_PER_TICK = 32e6
+_SECONDS_PER_TICK = 32e-6
 payloadtypes = {
     1: np.dtype(np.uint8),
     2: np.dtype(np.uint16),

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -1,8 +1,8 @@
 import re
-from functools import partial, reduce
-from pandas import DataFrame
-from typing import Iterable, Callable
-from harp.model import Model, Register
+from functools import partial
+from pandas import DataFrame, Series
+from typing import Iterable, Callable, Union
+from harp.model import BitMask, GroupMask, MaskValueItem, Model, Register
 from harp.io import read
 
 _camel_to_snake_regex = re.compile(r"(?<!^)(?=[A-Z])")
@@ -32,30 +32,48 @@ class DeviceReader:
         return self.registers[__name]
 
 
-def compose(f, g):
+def _compose(f, g):
     return lambda *a, **kw: f(g(*a, **kw))
 
 
-def id_camel_to_snake(id: str):
+def _id_camel_to_snake(id: str):
     return _camel_to_snake_regex.sub("_", id).lower()
 
 
-def keys_camel_to_snake(keys: Iterable[str]):
-    return [id_camel_to_snake(k) for k in keys]
+def _keys_camel_to_snake(keys: Iterable[str]):
+    return [_id_camel_to_snake(k) for k in keys]
 
 
-def create_bitreader(mask):
-    return lambda xs: ((xs & mask) != 0)
+def _create_bit_parser(mask: Union[int, MaskValueItem]):
+    def parser(xs: Series) -> Series:
+        return (xs & mask) != 0
+
+    return parser
 
 
-def create_reader(device: Model):
-    reg_readers = {
-        name: create_register_reader(device, name) for name in device.registers.keys()
-    }
-    return DeviceReader(device, reg_readers)
+def _create_bitmask_parser(bitMask: BitMask):
+    lookup = [
+        (_id_camel_to_snake(k), _create_bit_parser(v.root))
+        for k, v in bitMask.bits.items()
+    ]
+
+    def parser(df: DataFrame):
+        return DataFrame({n: f(df[0]) for n, f in lookup}, index=df.index)
+
+    return parser
 
 
-def create_register_reader(device: Model, name: str):
+def _create_groupmask_parser(name: str, groupMask: GroupMask):
+    name = _id_camel_to_snake(name)
+    lookup = {v.root: n for n, v in groupMask.values.items()}
+
+    def parser(df: DataFrame):
+        return DataFrame({name: df.map(lambda x: lookup[x])})
+
+    return parser
+
+
+def _create_register_reader(device: Model, name: str):
     register = device.registers[name]
     reader = read
 
@@ -63,31 +81,29 @@ def create_register_reader(device: Model, name: str):
         key = register.maskType.root
         bitMask = device.bitMasks.get(key)
         if bitMask is not None:
-            lookup = [
-                (id_camel_to_snake(k), create_bitreader(v.root))
-                for k, v in bitMask.bits.items()
-            ]
-
-            def unpack(df):
-                return DataFrame({n: f(df[0]) for n, f in lookup}, index=df.index)
-
-            reader = compose(unpack, reader)
+            parser = _create_bitmask_parser(bitMask)
+            reader = _compose(parser, reader)
             return RegisterReader(register, reader)
 
         groupMask = device.groupMasks.get(key)
         if groupMask is not None:
-            name = id_camel_to_snake(name)
-            lookup = {value.root: name for name, value in groupMask.values.items()}
-            reader = partial(reader, columns=[name])
-            reader = compose(lambda df: df.map(lambda x: lookup[x]), reader)
+            parser = _create_groupmask_parser(name, groupMask)
+            reader = _compose(parser, reader)
             return RegisterReader(register, reader)
 
     if register.payloadSpec is not None:
         columns = register.payloadSpec.keys()
-        columns = keys_camel_to_snake(columns)
+        columns = _keys_camel_to_snake(columns)
         reader = partial(reader, columns=columns)
         return RegisterReader(register, reader)
 
-    columns = [id_camel_to_snake(name)]
+    columns = [_id_camel_to_snake(name)]
     reader = partial(reader, columns=columns)
     return RegisterReader(register, reader)
+
+
+def create_reader(device: Model):
+    reg_readers = {
+        name: _create_register_reader(device, name) for name in device.registers.keys()
+    }
+    return DeviceReader(device, reg_readers)

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -25,6 +25,12 @@ class DeviceReader:
         self.model = model
         self.registers = registers
 
+    def __dir__(self) -> Iterable[str]:
+        return self.registers.keys()
+
+    def __getattr__(self, __name: str) -> RegisterReader:
+        return self.registers[__name]
+
 
 def compose(f, g):
     return lambda *a, **kw: f(g(*a, **kw))
@@ -44,7 +50,7 @@ def create_bitreader(mask):
 
 def create_reader(device: Model):
     reg_readers = {
-        create_register_reader(device, name) for name in device.registers.keys()
+        name: create_register_reader(device, name) for name in device.registers.keys()
     }
     return DeviceReader(device, reg_readers)
 

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -1,0 +1,71 @@
+import re
+from functools import partial, reduce
+from pandas import DataFrame
+from typing import Iterable, Callable
+from harp.model import Model, Register
+from harp.io import read
+
+_camel_to_snake_regex = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+class Reader:
+    register: Register
+    read: Callable[[str], DataFrame]
+
+    def __init__(self, register: Register, read: Callable[[str], DataFrame]) -> None:
+        self.register = register
+        self.read = read
+
+
+def compose(f, g):
+    return lambda *a, **kw: f(g(*a, **kw))
+
+
+def id_camel_to_snake(id: str):
+    return _camel_to_snake_regex.sub("_", id).lower()
+
+
+def keys_camel_to_snake(keys: Iterable[str]):
+    return [id_camel_to_snake(k) for k in keys]
+
+
+def create_bitreader(mask):
+    return lambda xs: ((xs & mask) != 0)
+
+
+def create_reader(device: Model, name: str):
+    register = device.registers[name]
+    reader = read
+
+    if register.maskType is not None:
+        key = register.maskType.root
+        bitMask = device.bitMasks.get(key)
+        if bitMask is not None:
+            lookup = [
+                (id_camel_to_snake(k), create_bitreader(v.root))
+                for k, v in bitMask.bits.items()
+            ]
+
+            def unpack(df):
+                return DataFrame({n: f(df[0]) for n, f in lookup}, index=df.index)
+
+            reader = compose(unpack, reader)
+            return Reader(register, reader)
+
+        groupMask = device.groupMasks.get(key)
+        if groupMask is not None:
+            name = id_camel_to_snake(name)
+            lookup = {value.root: name for name, value in groupMask.values.items()}
+            reader = partial(reader, columns=[name])
+            reader = compose(lambda df: df.map(lambda x: lookup[x]), reader)
+            return Reader(register, reader)
+
+    if register.payloadSpec is not None:
+        columns = register.payloadSpec.keys()
+        columns = keys_camel_to_snake(columns)
+        reader = partial(reader, columns=columns)
+        return Reader(register, reader)
+
+    columns = [id_camel_to_snake(name)]
+    reader = partial(reader, columns=columns)
+    return Reader(register, reader)

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -8,13 +8,22 @@ from harp.io import read
 _camel_to_snake_regex = re.compile(r"(?<!^)(?=[A-Z])")
 
 
-class Reader:
+class RegisterReader:
     register: Register
     read: Callable[[str], DataFrame]
 
     def __init__(self, register: Register, read: Callable[[str], DataFrame]) -> None:
         self.register = register
         self.read = read
+
+
+class DeviceReader:
+    model: Model
+    registers: dict[str, RegisterReader]
+
+    def __init__(self, model: Model, registers: dict[str, RegisterReader]) -> None:
+        self.model = model
+        self.registers = registers
 
 
 def compose(f, g):
@@ -33,7 +42,14 @@ def create_bitreader(mask):
     return lambda xs: ((xs & mask) != 0)
 
 
-def create_reader(device: Model, name: str):
+def create_reader(device: Model):
+    reg_readers = {
+        create_register_reader(device, name) for name in device.registers.keys()
+    }
+    return DeviceReader(device, reg_readers)
+
+
+def create_register_reader(device: Model, name: str):
     register = device.registers[name]
     reader = read
 
@@ -50,7 +66,7 @@ def create_reader(device: Model, name: str):
                 return DataFrame({n: f(df[0]) for n, f in lookup}, index=df.index)
 
             reader = compose(unpack, reader)
-            return Reader(register, reader)
+            return RegisterReader(register, reader)
 
         groupMask = device.groupMasks.get(key)
         if groupMask is not None:
@@ -58,14 +74,14 @@ def create_reader(device: Model, name: str):
             lookup = {value.root: name for name, value in groupMask.values.items()}
             reader = partial(reader, columns=[name])
             reader = compose(lambda df: df.map(lambda x: lookup[x]), reader)
-            return Reader(register, reader)
+            return RegisterReader(register, reader)
 
     if register.payloadSpec is not None:
         columns = register.payloadSpec.keys()
         columns = keys_camel_to_snake(columns)
         reader = partial(reader, columns=columns)
-        return Reader(register, reader)
+        return RegisterReader(register, reader)
 
     columns = [id_camel_to_snake(name)]
     reader = partial(reader, columns=columns)
-    return Reader(register, reader)
+    return RegisterReader(register, reader)

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -18,11 +18,11 @@ class RegisterReader:
 
 
 class DeviceReader:
-    model: Model
+    device: Model
     registers: dict[str, RegisterReader]
 
-    def __init__(self, model: Model, registers: dict[str, RegisterReader]) -> None:
-        self.model = model
+    def __init__(self, device: Model, registers: dict[str, RegisterReader]) -> None:
+        self.device = device
         self.registers = registers
 
     def __dir__(self) -> Iterable[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,6 @@ extend-exclude = '''
   ^/LICENSE
   ^/README.md
   | harp/model.py
+  | reflex-generator
 )
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,15 +31,17 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "datamodel-code-generator",
-    "setuptools_scm",
     "black"
+]
+jupyter = [
+    "ipykernel"
 ]
 
 [build-system]
 requires = [
-    "setuptools>=45",
     "wheel",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools",
+    "setuptools_scm[toml]",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This PR introduces high-level infrastructure for automatically creating efficient register payload readers from a device metadata file. The proposed API parses an existing device schema and creates a data frame processing pipeline using function composition. Each step aims to use only efficient pandas operators so the final data extraction can be made as fast as possible.

The returned `DeviceReader` object is a dynamic collection of register readers, supporting automatic code-completion and leveraging parsed device metadata to maximize contextual exploration of device data.