### PR TITLE
Add support for keeping message type

### DIFF
--- a/harp/io.py
+++ b/harp/io.py
@@ -15,7 +15,7 @@ class MessageType(IntEnum):
 
 _SECONDS_PER_TICK = 32e-6
 _messagetypes = [type.name for type in MessageType]
-payloadtypes = {
+_payloadtypes = {
     1: np.dtype(np.uint8),
     2: np.dtype(np.uint16),
     4: np.dtype(np.uint32),
@@ -80,7 +80,7 @@ def read(
         index.name = "time"
 
     payloadsize = stride - payloadoffset - 1
-    payloadtype = payloadtypes[payloadtype]
+    payloadtype = _payloadtypes[payloadtype]
     if dtype is not None and dtype != payloadtype:
         raise ValueError(f"expected payload type {dtype} but got {payloadtype}")
 


### PR DESCRIPTION
This PR extends the `read` method with support for keeping message type when reading harp binary files. The feature is implemented using [`Categorical.from_codes`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Categorical.from_codes.html) to efficiently map from raw message type values to strings.

The resulting categorical column can be compared using either names or codes in the `MessageType` enum.