### PR TITLE
Refactor modules for type checking

### DIFF
--- a/harp/io.py
+++ b/harp/io.py
@@ -84,7 +84,7 @@ def read(
         time = micros * _SECONDS_PER_TICK + seconds
         payloadtype = payloadtype & ~0x10
         if epoch is not None:
-            time = epoch + pd.to_timedelta(time, "s")
+            time = epoch + pd.to_timedelta(time, "s") # type: ignore
         index = pd.Series(time)
         index.name = "time"
 
@@ -111,6 +111,6 @@ def read(
         msgtype = np.ndarray(
             nrows, dtype=np.uint8, buffer=data, offset=0, strides=stride
         )
-        msgtype = pd.Categorical.from_codes(msgtype, categories=_messagetypes)
+        msgtype = pd.Categorical.from_codes(msgtype, categories=_messagetypes) # type: ignore
         result["type"] = msgtype
     return result

--- a/harp/model.py
+++ b/harp/model.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 from typing_extensions import Annotated
 
 from pydantic import (
@@ -14,7 +14,6 @@ from pydantic import (
     ConfigDict,
     Field,
     RootModel,
-    conint,
     field_serializer,
 )
 
@@ -135,13 +134,19 @@ class Visibility(Enum):
 
 
 class Register(BaseModel):
-    address: conint(le=255) = Field(
-        ..., description="Specifies the unique 8-bit address of the register."
-    )
+    address: Annotated[
+        int,
+        Field(
+            le=255, description="Specifies the unique 8-bit address of the register."
+        ),
+    ]
     type: Annotated[PayloadType, BeforeValidator(lambda v: PayloadType[v])]
-    length: Optional[conint(ge=1)] = Field(
-        default=1, description="Specifies the length of the register payload."
-    )
+    length: Annotated[
+        Optional[int],
+        Field(
+            ge=1, default=1, description="Specifies the length of the register payload."
+        ),
+    ]
     access: Union[Access, List[Access]] = Field(
         ..., description="Specifies the expected use of the register."
     )

--- a/harp/model.py
+++ b/harp/model.py
@@ -8,34 +8,42 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, RootModel, conint, field_serializer
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    RootModel,
+    conint,
+    field_serializer,
+)
 
 
 class PayloadType(str, Enum):
-    U8 = 'uint8'
-    S8 = 'int8'
-    U16 = 'uint16'
-    S16 = 'int16'
-    U32 = 'uint32'
-    S32 = 'int32'
-    U64 = 'uint64'
-    S64 = 'int64'
-    Float = 'float32'
+    U8 = "uint8"
+    S8 = "int8"
+    U16 = "uint16"
+    S16 = "int16"
+    U32 = "uint32"
+    S32 = "int32"
+    U64 = "uint64"
+    S64 = "int64"
+    Float = "float32"
 
 
 class Access(Enum):
-    Read = 'Read'
-    Write = 'Write'
-    Event = 'Event'
+    Read = "Read"
+    Write = "Write"
+    Event = "Event"
 
 
 class MaskValueItem(BaseModel):
     model_config = ConfigDict(
-        extra='forbid',
+        extra="forbid",
     )
-    value: int = Field(..., description='Specifies the numerical mask value.')
+    value: int = Field(..., description="Specifies the numerical mask value.")
     description: Optional[str] = Field(
-        None, description='Specifies a summary description of the mask value function.'
+        None, description="Specifies a summary description of the mask value function."
     )
 
     def __int__(self):
@@ -48,14 +56,14 @@ class MaskValue(RootModel[Union[int, MaskValueItem]]):
 
 class BitMask(BaseModel):
     description: Optional[str] = Field(
-        None, description='Specifies a summary description of the bit mask function.'
+        None, description="Specifies a summary description of the bit mask function."
     )
     bits: Dict[str, MaskValue]
 
 
 class GroupMask(BaseModel):
     description: Optional[str] = Field(
-        None, description='Specifies a summary description of the group mask function.'
+        None, description="Specifies a summary description of the group mask function."
     )
     values: Dict[str, MaskValue]
 
@@ -63,55 +71,55 @@ class GroupMask(BaseModel):
 class MaskType(RootModel[str]):
     root: str = Field(
         ...,
-        description='Specifies the name of the bit mask or group mask used to represent the payload value.',
+        description="Specifies the name of the bit mask or group mask used to represent the payload value.",
     )
 
 
 class InterfaceType(RootModel[str]):
     root: str = Field(
         ...,
-        description='Specifies the name of the type used to represent the payload value in the high-level interface.',
+        description="Specifies the name of the type used to represent the payload value in the high-level interface.",
     )
 
 
 class Converter(Enum):
-    None_ = 'None'
-    Payload = 'Payload'
-    RawPayload = 'RawPayload'
+    None_ = "None"
+    Payload = "Payload"
+    RawPayload = "RawPayload"
 
 
 class MinValue(RootModel[float]):
     root: float = Field(
         ...,
-        description='Specifies the minimum allowable value for the payload or payload member.',
+        description="Specifies the minimum allowable value for the payload or payload member.",
     )
 
 
 class MaxValue(RootModel[float]):
     root: float = Field(
         ...,
-        description='Specifies the maximum allowable value for the payload or payload member.',
+        description="Specifies the maximum allowable value for the payload or payload member.",
     )
 
 
 class DefaultValue(RootModel[float]):
     root: float = Field(
         ...,
-        description='Specifies the default value for the payload or payload member.',
+        description="Specifies the default value for the payload or payload member.",
     )
 
 
 class PayloadMember(BaseModel):
     mask: Optional[int] = Field(
         None,
-        description='Specifies the mask used to read and write this payload member.',
+        description="Specifies the mask used to read and write this payload member.",
     )
     offset: Optional[int] = Field(
         None,
-        description='Specifies the payload array offset where this payload member is stored.',
+        description="Specifies the payload array offset where this payload member is stored.",
     )
     description: Optional[str] = Field(
-        None, description='Specifies a summary description of the payload member.'
+        None, description="Specifies a summary description of the payload member."
     )
     minValue: Optional[MinValue] = None
     maxValue: Optional[MaxValue] = None
@@ -122,23 +130,23 @@ class PayloadMember(BaseModel):
 
 
 class Visibility(Enum):
-    public = 'public'
-    private = 'private'
+    public = "public"
+    private = "private"
 
 
 class Register(BaseModel):
     address: conint(le=255) = Field(
-        ..., description='Specifies the unique 8-bit address of the register.'
+        ..., description="Specifies the unique 8-bit address of the register."
     )
     type: Annotated[PayloadType, BeforeValidator(lambda v: PayloadType[v])]
     length: Optional[conint(ge=1)] = Field(
-        default=1, description='Specifies the length of the register payload.'
+        default=1, description="Specifies the length of the register payload."
     )
     access: Union[Access, List[Access]] = Field(
-        ..., description='Specifies the expected use of the register.'
+        ..., description="Specifies the expected use of the register."
     )
     description: Optional[str] = Field(
-        None, description='Specifies a summary description of the register function.'
+        None, description="Specifies a summary description of the register function."
     )
     minValue: Optional[MinValue] = None
     maxValue: Optional[MaxValue] = None
@@ -146,17 +154,17 @@ class Register(BaseModel):
     maskType: Optional[MaskType] = None
     visibility: Optional[Visibility] = Field(
         None,
-        description='Specifies whether the register function is exposed in the high-level interface.',
+        description="Specifies whether the register function is exposed in the high-level interface.",
     )
     volatile: Optional[bool] = Field(
         None,
-        description='Specifies whether register values can be saved in non-volatile memory.',
+        description="Specifies whether register values can be saved in non-volatile memory.",
     )
     payloadSpec: Optional[Dict[str, PayloadMember]] = None
     interfaceType: Optional[InterfaceType] = None
     converter: Optional[Converter] = None
 
-    @field_serializer('type')
+    @field_serializer("type")
     def _serialize_type(self, type: PayloadType):
         return type.name
 
@@ -164,26 +172,26 @@ class Register(BaseModel):
 class Registers(BaseModel):
     registers: Dict[str, Register] = Field(
         ...,
-        description='Specifies the collection of registers implementing the device function.',
+        description="Specifies the collection of registers implementing the device function.",
     )
     bitMasks: Optional[Dict[str, BitMask]] = Field(
         None,
-        description='Specifies the collection of masks available to be used with the different registers.',
+        description="Specifies the collection of masks available to be used with the different registers.",
     )
     groupMasks: Optional[Dict[str, GroupMask]] = Field(
         None,
-        description='Specifies the collection of group masks available to be used with the different registers.',
+        description="Specifies the collection of group masks available to be used with the different registers.",
     )
 
 
 class Model(Registers):
-    device: str = Field(..., description='Specifies the name of the device.')
+    device: str = Field(..., description="Specifies the name of the device.")
     whoAmI: int = Field(
-        ..., description='Specifies the unique identifier for this device type.'
+        ..., description="Specifies the unique identifier for this device type."
     )
     firmwareVersion: str = Field(
-        ..., description='Specifies the semantic version of the device firmware.'
+        ..., description="Specifies the semantic version of the device firmware."
     )
     hardwareTargets: str = Field(
-        ..., description='Specifies the semantic version of the device hardware.'
+        ..., description="Specifies the semantic version of the device hardware."
     )

--- a/harp/schema.py
+++ b/harp/schema.py
@@ -8,24 +8,26 @@ _common_yaml_path = Path(__file__).absolute().parent.joinpath("common.yml")
 
 
 def _read_common_registers(file: Union[str, PathLike, TextIO]) -> Registers:
-    try:
+    if isinstance(file, TextIO):
+        return parse_yaml_raw_as(Registers, file.read())
+    else:
         with open(file) as fileIO:
             return _read_common_registers(fileIO)
-    except TypeError:
-        return parse_yaml_raw_as(Registers, file.read())
 
 
 def read_schema(
     file: Union[str, PathLike, TextIO], include_common_registers: bool = True
 ) -> Model:
-    try:
-        with open(file) as fileIO:
-            return read_schema(fileIO, include_common_registers)
-    except TypeError:
+    if isinstance(file, TextIO):
         schema = parse_yaml_raw_as(Model, file.read())
         if not "WhoAmI" in schema.registers and include_common_registers:
             common = _read_common_registers(_common_yaml_path)
             schema.registers = dict(common.registers, **schema.registers)
-            schema.bitMasks = dict(common.bitMasks, **schema.bitMasks)
-            schema.groupMasks = dict(common.groupMasks, **schema.groupMasks)
+            if schema.bitMasks is not None and common.bitMasks is not None:
+                schema.bitMasks = dict(common.bitMasks, **schema.bitMasks)
+            if schema.groupMasks is not None and common.groupMasks is not None:
+                schema.groupMasks = dict(common.groupMasks, **schema.groupMasks)
         return schema
+    else:
+        with open(file) as fileIO:
+            return read_schema(fileIO, include_common_registers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ extend-exclude = '''
 (
   ^/LICENSE
   ^/README.md
-  | harp/model.py
   | reflex-generator
 )
 '''

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
-from typing import Iterable, Optional, Type
+from os import PathLike
+from typing import Iterable, Optional, Type, Union
 from contextlib import nullcontext
 from pytest import mark
 from pathlib import Path
@@ -12,7 +13,7 @@ datapath = Path(__file__).parent
 
 @dataclass
 class DataFileParam:
-    path: str
+    path: Union[str, PathLike]
     expected_rows: int
     expected_cols: Optional[Iterable[str]] = None
     expected_address: Optional[int] = None
@@ -36,7 +37,7 @@ testdata = [
     DataFileParam(
         path="data/device_0.bin",
         expected_rows=1,
-        expected_dtype="uint8",  # actual dtype is uint16
+        expected_dtype=np.dtype("uint8"),  # actual dtype is uint16
         expected_error=ValueError,
     ),
     DataFileParam(
@@ -55,7 +56,7 @@ testdata = [
 @mark.parametrize("dataFile", testdata)
 def test_read(dataFile: DataFileParam):
     context = pytest.raises if dataFile.expected_error is not None else nullcontext
-    with context(dataFile.expected_error):
+    with context(dataFile.expected_error):  # type: ignore
         data = read(
             dataFile.path,
             address=dataFile.expected_address,


### PR DESCRIPTION
This PR refactors the module source to ensure successful type checking. Apart from a few minor edge cases which require further investigation (mostly operations that should be well-defined to the type checker but for some reason are not), the source is now fully annotated and validated.