### PR TITLE
Add unit tests for reader module

### DIFF
--- a/tests/data/device.yml
+++ b/tests/data/device.yml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/harp-tech/reflex-generator/main/schema/device.json
-device: TestDevice
+device: device
 whoAmI: 0000
 firmwareVersion: "0.1"
 hardwareTargets: "0.1"

--- a/tests/params.py
+++ b/tests/params.py
@@ -1,0 +1,41 @@
+import numpy as np
+from os import PathLike
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Iterable, Optional, Type, Union
+from harp.model import Model
+
+datapath = Path(__file__).parent
+
+
+@dataclass
+class DataFileParam:
+    path: Union[str, PathLike]
+    expected_rows: int
+    expected_cols: Optional[Iterable[str]] = None
+    expected_address: Optional[int] = None
+    expected_dtype: Optional[np.dtype] = None
+    expected_length: Optional[int] = None
+    expected_error: Optional[Type[BaseException]] = None
+    keep_type: bool = False
+
+    def __post_init__(self):
+        self.path = datapath / self.path
+
+
+@dataclass
+class DeviceSchemaParam:
+    path: Union[str, PathLike]
+    expected_whoAmI: int
+    expected_device: Optional[int] = None
+    expected_registers: Optional[Iterable[str]] = None
+    expected_error: Optional[Type[BaseException]] = None
+
+    def __post_init__(self):
+        self.path = datapath / self.path
+
+    def assert_schema(self, device: Model):
+        assert device.whoAmI == self.expected_whoAmI
+        if self.expected_registers:
+            for register in self.expected_registers:
+                assert register in device.registers

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,30 +1,9 @@
 import pytest
 import numpy as np
-from os import PathLike
-from typing import Iterable, Optional, Type, Union
 from contextlib import nullcontext
 from pytest import mark
-from pathlib import Path
-from dataclasses import dataclass
 from harp.io import read
-
-datapath = Path(__file__).parent
-
-
-@dataclass
-class DataFileParam:
-    path: Union[str, PathLike]
-    expected_rows: int
-    expected_cols: Optional[Iterable[str]] = None
-    expected_address: Optional[int] = None
-    expected_dtype: Optional[np.dtype] = None
-    expected_length: Optional[int] = None
-    expected_error: Optional[Type[BaseException]] = None
-    keep_type: bool = False
-
-    def __post_init__(self):
-        self.path = datapath / self.path
-
+from tests.params import DataFileParam
 
 testdata = [
     DataFileParam(path="data/device_0.bin", expected_rows=1),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -71,7 +71,3 @@ def test_read(dataFile: DataFileParam):
         if dataFile.expected_cols:
             for col in dataFile.expected_cols:
                 assert col in data.columns
-
-
-if __name__ == "__main__":
-    pytest.main()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,17 @@
+from pytest import mark
+from harp.reader import create_reader
+from tests.params import DeviceSchemaParam
+
+testdata = [
+    DeviceSchemaParam(
+        path="data/device.yml",
+        expected_whoAmI=0,
+        expected_registers=["DigitalInputMode"],
+    )
+]
+
+
+@mark.parametrize("schemaFile", testdata)
+def test_create_reader(schemaFile: DeviceSchemaParam):
+    reader = create_reader(schemaFile.path)
+    schemaFile.assert_schema(reader.device)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,25 +1,6 @@
-import pytest
-from os import PathLike
-from typing import Iterable, Optional, Type, Union
 from pytest import mark
-from pathlib import Path
-from dataclasses import dataclass
 from harp.schema import read_schema
-
-datapath = Path(__file__).parent
-
-
-@dataclass
-class DeviceSchemaParam:
-    path: Union[str, PathLike]
-    expected_whoAmI: int
-    expected_device: Optional[int] = None
-    expected_registers: Optional[Iterable[str]] = None
-    expected_error: Optional[Type[BaseException]] = None
-
-    def __post_init__(self):
-        self.path = datapath / self.path
-
+from tests.params import DeviceSchemaParam
 
 testdata = [
     DeviceSchemaParam(
@@ -32,12 +13,5 @@ testdata = [
 
 @mark.parametrize("schemaFile", testdata)
 def test_read_schema(schemaFile: DeviceSchemaParam):
-    schema = read_schema(schemaFile.path)
-    assert schema.whoAmI == schemaFile.expected_whoAmI
-    if schemaFile.expected_registers:
-        for register in schemaFile.expected_registers:
-            assert register in schema.registers
-
-
-if __name__ == "__main__":
-    pytest.main()
+    device = read_schema(schemaFile.path)
+    schemaFile.assert_schema(device)


### PR DESCRIPTION
This PR sets up parametric testing for the `create_reader` method, with and without validation. It builds up upon the existing tests for the `schema` module with the goal of regression testing new features.