### PR TITLE
Add support for passing optional parameters to register reader

### DIFF
--- a/harp/reader.py
+++ b/harp/reader.py
@@ -3,6 +3,7 @@ import re
 from math import log2
 from os import PathLike
 from pathlib import Path
+from datetime import datetime
 from functools import partial
 from numpy import dtype
 from pandas import DataFrame, Series
@@ -17,7 +18,9 @@ _camel_to_snake_regex = re.compile(r"(?<!^)(?=[A-Z])")
 
 class _ReadRegister(Protocol):
     def __call__(
-        self, file: Optional[Union[str, bytes, PathLike[Any], BinaryIO]] = None
+        self,
+        file: Optional[Union[str, bytes, PathLike[Any], BinaryIO]] = None,
+        epoch: Optional[datetime] = None,
     ) -> DataFrame:
         ...
 
@@ -134,6 +137,7 @@ def _create_register_reader(register: Register, base_path: Path):
     def reader(
         file: Optional[Union[str, bytes, PathLike[Any], BinaryIO]] = None,
         columns: Optional[Axes] = None,
+        epoch: Optional[datetime] = None,
     ):
         if file is None:
             file = f"{base_path}_{register.address}.bin"
@@ -144,6 +148,7 @@ def _create_register_reader(register: Register, base_path: Path):
             dtype=dtype(register.type),
             length=register.length,
             columns=columns,
+            epoch=epoch,
         )
         return data
 

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from functools import partial
 from numpy import dtype
 from pandas import DataFrame, Series
-from typing import Any, BinaryIO, Iterable, Optional, Protocol, Union
+from typing import Any, BinaryIO, Callable, Iterable, Optional, Protocol, Union
 from pandas._typing import Axes
 from harp.model import BitMask, GroupMask, Model, PayloadMember, Register
 from harp.io import read
@@ -21,6 +21,7 @@ class _ReadRegister(Protocol):
         self,
         file: Optional[Union[str, bytes, PathLike[Any], BinaryIO]] = None,
         epoch: Optional[datetime] = None,
+        keep_type: bool = False,
     ) -> DataFrame:
         ...
 
@@ -53,8 +54,23 @@ class DeviceReader:
         return self.registers[__name]
 
 
-def _compose(f, g):
-    return lambda *a, **kw: f(g(*a, **kw))
+def _compose_parser(
+    f: Callable[[DataFrame], DataFrame], g: Callable[..., DataFrame]
+) -> Callable[..., DataFrame]:
+    def parser(
+        file: Optional[Union[str, bytes, PathLike[Any], BinaryIO]] = None,
+        columns: Optional[Axes] = None,
+        epoch: Optional[datetime] = None,
+        keep_type: bool = False,
+    ):
+        df = g(file, columns, epoch, keep_type)
+        result = f(df)
+        type_col = df.get("type")
+        if type_col is not None:
+            result["type"] = type_col
+        return result
+
+    return parser
 
 
 def _id_camel_to_snake(id: str):
@@ -138,6 +154,7 @@ def _create_register_reader(register: Register, base_path: Path):
         file: Optional[Union[str, bytes, PathLike[Any], BinaryIO]] = None,
         columns: Optional[Axes] = None,
         epoch: Optional[datetime] = None,
+        keep_type: bool = False,
     ):
         if file is None:
             file = f"{base_path}_{register.address}.bin"
@@ -149,6 +166,7 @@ def _create_register_reader(register: Register, base_path: Path):
             length=register.length,
             columns=columns,
             epoch=epoch,
+            keep_type=keep_type,
         )
         return data
 
@@ -164,13 +182,13 @@ def _create_register_parser(device: Model, name: str, base_path: Path):
         bitMask = None if device.bitMasks is None else device.bitMasks.get(key)
         if bitMask is not None:
             parser = _create_bitmask_parser(bitMask)
-            reader = _compose(parser, reader)
+            reader = _compose_parser(parser, reader)
             return RegisterReader(register, reader)
 
         groupMask = None if device.groupMasks is None else device.groupMasks.get(key)
         if groupMask is not None:
             parser = _create_groupmask_parser(name, groupMask)
-            reader = _compose(parser, reader)
+            reader = _compose_parser(parser, reader)
             return RegisterReader(register, reader)
 
     if register.payloadSpec is not None:
@@ -182,7 +200,7 @@ def _create_register_parser(device: Model, name: str, base_path: Path):
         def parser(df: DataFrame):
             return DataFrame({n: f(df) for n, f in payload_parsers}, index=df.index)
 
-        reader = _compose(parser, reader)
+        reader = _compose_parser(parser, reader)
         return RegisterReader(register, reader)
 
     columns = [_id_camel_to_snake(name)]

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -12,7 +12,7 @@ testdata = [
         path="data/device.yml",
         expected_whoAmI=0,
         expected_registers=["DigitalInputMode"],
-    )
+    ),
 ]
 
 


### PR DESCRIPTION
This feature allows passing all optional parameters to register reader. The reader module was refactored so that all extra columns, e.g. `type` are included in the final frame after all conversion steps are applied.

For example, the below example retrieves the frame using UTC time and including the message type for all recorded messages:

```python
from harp.io import REFERENCE_EPOCH
from harp.reader import create_reader

reader = create_reader('device.harp')
reader.WhoAmI.read(epoch=REFERENCE_EPOCH, keep_type=True)
```