### PR TITLE
Allow setting default params when creating device reader

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,4 +1,6 @@
+import numpy as np
 from pytest import mark
+from harp.io import REFERENCE_EPOCH, MessageType
 from harp.reader import create_reader
 from tests.params import DeviceSchemaParam
 
@@ -18,8 +20,13 @@ testdata = [
 
 @mark.parametrize("schemaFile", testdata)
 def test_create_reader(schemaFile: DeviceSchemaParam):
-    reader = create_reader(schemaFile.path)
+    reader = create_reader(schemaFile.path, epoch=REFERENCE_EPOCH)
     schemaFile.assert_schema(reader.device)
 
     whoAmI = reader.WhoAmI.read()
     assert reader.device.whoAmI == whoAmI.iloc[0, 0]
+    assert whoAmI.index.dtype.type == np.datetime64
+
+    whoAmI = reader.WhoAmI.read(epoch=None, keep_type=True)
+    assert whoAmI.index.dtype.type == np.float64
+    assert whoAmI.iloc[0, -1] == MessageType.READ.name


### PR DESCRIPTION
This feature allows setting a default reference epoch and other common params for all register readers when creating the device reader from a schema or folder, to make it easier to setup consistent data frame outputs and reduce bookkeeping.

For example, you can set a common reference epoch at the top and then get consistent time indices for all dataframes:

```python
from harp.io import REFERENCE_EPOCH

reader = create_reader('device.ylm', epoch=REFERENCE_EPOCH)
reader.WhoAmI.read()
```

It is also possible to override the parameters for individual reads, e.g. `reader.WhoAmI.read(keep_type=True)` will make the type column visible no matter what the default setting is.