### PR TITLE
Change column names to match schema casing

### DIFF
--- a/harp/io.py
+++ b/harp/io.py
@@ -61,7 +61,7 @@ def read(
     data = np.fromfile(file, dtype=np.uint8)
     if len(data) == 0:
         return pd.DataFrame(
-            columns=columns, index=pd.Index([], dtype=np.float64, name="time")
+            columns=columns, index=pd.Index([], dtype=np.float64, name="Time")
         )
 
     if address is not None and address != data[2]:
@@ -86,7 +86,7 @@ def read(
         if epoch is not None:
             time = epoch + pd.to_timedelta(time, "s")  # type: ignore
         index = pd.Series(time)
-        index.name = "time"
+        index.name = "Time"
 
     payloadsize = stride - payloadoffset - 1
     payloadtype = _payloadtypes[payloadtype]
@@ -112,5 +112,5 @@ def read(
             nrows, dtype=np.uint8, buffer=data, offset=0, strides=stride
         )
         msgtype = pd.Categorical.from_codes(msgtype, categories=_messagetypes)  # type: ignore
-        result["type"] = msgtype
+        result[MessageType.__name__] = msgtype
     return result

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from contextlib import nullcontext
 from pytest import mark
-from harp.io import read
+from harp.io import read, MessageType
 from tests.params import DataFileParam
 
 testdata = [
@@ -45,7 +45,10 @@ def test_read(dataFile: DataFileParam):
         )
         assert len(data) == dataFile.expected_rows
         if dataFile.keep_type:
-            assert "type" in data.columns and data["type"].dtype == "category"
+            assert (
+                MessageType.__name__ in data.columns
+                and data[MessageType.__name__].dtype == "category"
+            )
 
         if dataFile.expected_cols:
             for col in dataFile.expected_cols:


### PR DESCRIPTION
In the first version of the interface there was an attempt to make naming of decoded columns match the recommended style for local variables in Python (snake_case). However, this required automatically transforming the casing of names specified in Harp schemas (typically Pascal-cased). This transformation was found to be broken in several important edge cases.

For this new release, we decided to keep the original styling of schemas, rather than attempting to fix the transformation, which will also increase consistency with the names of automatically generated Reader classes.

This PR essentially removes all casing transformations from the reader pipeline and makes column names fully aligned with device schema naming conventions. The built-in columns for time and message type were also changed to Pascal-case for uniformity.