### PR TITLE
Ensure manifest tracks package version via module's `__version__` attribute

### DIFF
--- a/harp/__init__.py
+++ b/harp/__init__.py
@@ -1,3 +1,5 @@
 from harp.io import REFERENCE_EPOCH, MessageType, read
 from harp.reader import create_reader
 from harp.schema import read_schema
+
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = ["harp*"]
 
+[tool.setuptools.dynamic]
+version = {attr = "harp.__version__"}
+
 [tool.setuptools_scm]
 
 [tool.black]


### PR DESCRIPTION
This PR splits an independent commit from #26 to allow the project.toml manifest file to track the version of the package from a private `__version__` attribute.

Users can also now get the version by calling:
```python
import harp
version = harp.__version__
``` 