### PR TITLE
Remove redundant file mode

### DIFF
--- a/harp/schema.py
+++ b/harp/schema.py
@@ -9,7 +9,7 @@ from harp.model import Model, Registers
 
 def _read_common_registers() -> Registers:
     file = resources.files(__package__) / "common.yml"
-    with file.open("rt") as fileIO:
+    with file.open("r") as fileIO:
         return parse_yaml_raw_as(Registers, fileIO.read())
 
 


### PR DESCRIPTION
Pylance kept complaining about the redundant file mode and indeed the default for open is already text mode, so no need to have it here.