### PR TITLE
Avoid silent overflow for numpy compatibility

### DIFF
--- a/harp/io.py
+++ b/harp/io.py
@@ -90,7 +90,7 @@ def read(
         micros = np.ndarray(nrows, dtype=np.uint16, buffer=data, offset=payloadoffset, strides=stride)
         payloadoffset += 2
         time = micros * _SECONDS_PER_TICK + seconds
-        payloadtype = payloadtype & ~0x10
+        payloadtype = payloadtype & ~np.uint8(0x10)
         if epoch is not None:
             time = epoch + pd.to_timedelta(time, "s")  # type: ignore
         index = pd.Series(time)

--- a/harp/io.py
+++ b/harp/io.py
@@ -80,7 +80,7 @@ def read(
         raise ValueError(f"expected address {address} but got {data[2]}")
 
     index = None
-    stride = data[1] + 2
+    stride = int(data[1] + 2)
     nrows = len(data) // stride
     payloadtype = data[4]
     payloadoffset = 5


### PR DESCRIPTION
NumPy 2.0 disallows silent overflow when converting to unsigned dtypes which was causing parsing to fail when reading timestamped registers.

This PR introduces an early explicit conversion to prevent overflow and ensure full compatibility with NumPy 1.26+ and NumPy 2.0+.

Fixes #32 