### PR TITLE
Add CI pipeline and code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.9, 3.11]
       fail-fast: false
-    defaults:
-      run:
-        shell: ${{ matrix.os == 'windows-latest' && 'cmd' || 'bash' }} -l {0} # Adjust shell based on OS
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,16 +25,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Create venv and install dependencies
-        run: |
-          python -m venv .venv
-          .venv/Scripts/activate || source .venv/bin/activate
-          pip install -e .[dev]
-      - name: Activate venv for later steps
-        run: |
-          echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
-          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH      # For Unix-like systems
-          echo "$(pwd)/.venv/Scripts" >> $GITHUB_PATH  # For Windows
+      - name: Install dependencies
+        run: pip install -e .[dev]
 
       - name: ruff
         run: ruff check .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_run_tests:
-    name: Build env using pip and pyproject.toml on ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: pip install -e .[dev]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+# Builds the python environment; linter and formatting via ruff; type annotations via pyright;
+# tests via pytest; reports test coverage via pytest-cov.
+
+name: build
+on:
+  push:
+    branches: ['*']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_run_tests:
+    name: Build env using pip and pyproject.toml on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.9, 3.11]
+      fail-fast: false
+    defaults:
+      run:
+        shell: ${{ matrix.os == 'windows-latest' && 'cmd' || 'bash' }} -l {0} # Adjust shell based on OS
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create venv and install dependencies
+        run: |
+          python -m venv .venv
+          .venv/Scripts/activate || source .venv/bin/activate
+          pip install -e .[dev]
+      - name: Activate venv for later steps
+        run: |
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH      # For Unix-like systems
+          echo "$(pwd)/.venv/Scripts" >> $GITHUB_PATH  # For Windows
+
+      - name: ruff
+        run: ruff check .
+      - name: pyright
+        run: pyright . 
+      - name: pytest
+        run: pytest --cov harp

--- a/harp/__init__.py
+++ b/harp/__init__.py
@@ -1,3 +1,5 @@
 from harp.io import REFERENCE_EPOCH, MessageType, read
 from harp.reader import create_reader
 from harp.schema import read_schema
+
+__all__ = ["REFERENCE_EPOCH", "MessageType", "read", "create_reader", "read_schema"]

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -53,11 +53,11 @@ class RegisterMap(UserDict[str, RegisterReader]):
         super().__init__(registers)
         self._address_map = {value.register.address: value for value in registers.values()}
 
-    def __getitem__(self, __key: Union[str, int]) -> RegisterReader:
-        if isinstance(__key, int):
-            return self._address_map[__key]
+    def __getitem__(self, key: Union[str, int]) -> RegisterReader:
+        if isinstance(key, int):
+            return self._address_map[key]
         else:
-            return super().__getitem__(__key)
+            return super().__getitem__(key)
 
 
 class DeviceReader:

--- a/harp/schema.py
+++ b/harp/schema.py
@@ -35,7 +35,7 @@ def read_schema(file: Union[str, PathLike, TextIO], include_common_registers: bo
             return read_schema(fileIO)
     else:
         schema = parse_yaml_raw_as(Model, file.read())
-        if not "WhoAmI" in schema.registers and include_common_registers:
+        if "WhoAmI" not in schema.registers and include_common_registers:
             common = _read_common_registers()
             schema.registers = dict(common.registers, **schema.registers)
             if common.bitMasks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,10 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "datamodel-code-generator",
+    "pandas-stubs",
     "pytest",
-    "black",
-    "isort",
+    "pyright",
+    "ruff",
     "codespell"
 ]
 
@@ -58,23 +59,20 @@ include = ["harp*"]
 
 [tool.setuptools_scm]
 
-[tool.black]
+[tool.ruff]
 line-length = 108
-target-version = ['py39']
-include = '\.pyi?$'
-extend-exclude = '''
-# A regex preceded with ^/ will apply only to files and directories
-# in the root of the project.
-(
-  ^/LICENSE
-  ^/README.md
-  | reflex-generator
-)
-'''
+target-version = "py39"
+exclude = [
+    "reflex-generator"
+]
 
-[tool.isort]
-profile = 'black'
-extend_skip = 'reflex-generator'
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+exclude = [
+    ".venv/*",
+    "reflex-generator"
+]
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "datamodel-code-generator",
     "pandas-stubs",
     "pytest",
+    "pytest-cov",
     "pyright",
     "ruff",
     "codespell"


### PR DESCRIPTION
To improve the process for external code contributions, this PR adds a CI pipeline using `ruff`, `pyright` and `pytest` with preliminary support for code coverage. Badges are not generated yet but all outputs are there and a few outstanding recommendations have been applied.

Tests are run against python 3.9 and 3.11 for now on all platforms.