### PR TITLE
Add support for parsing data from a memory buffer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, 3.11]
+        python-version: [3.9, 3.12]
       fail-fast: false
     steps:
       - name: Checkout

--- a/harp/__init__.py
+++ b/harp/__init__.py
@@ -1,5 +1,5 @@
-from harp.io import REFERENCE_EPOCH, MessageType, read
+from harp.io import REFERENCE_EPOCH, MessageType, parse, read
 from harp.reader import create_reader
 from harp.schema import read_schema
 
-__all__ = ["REFERENCE_EPOCH", "MessageType", "read", "create_reader", "read_schema"]
+__all__ = ["REFERENCE_EPOCH", "MessageType", "parse", "read", "create_reader", "read_schema"]

--- a/harp/model.py
+++ b/harp/model.py
@@ -7,14 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Annotated, Dict, List, Optional, Union
 
-from pydantic import (
-    BaseModel,
-    BeforeValidator,
-    ConfigDict,
-    Field,
-    RootModel,
-    field_serializer,
-)
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, RootModel, field_serializer
 
 
 class PayloadType(str, Enum):

--- a/harp/typing.py
+++ b/harp/typing.py
@@ -1,0 +1,10 @@
+import mmap
+import sys
+from typing import Any, Union
+
+from numpy.typing import NDArray
+
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer as BufferLike
+else:
+    BufferLike = Union[bytes, bytearray, memoryview, mmap.mmap, NDArray[Any]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ exclude = [
     "reflex-generator"
 ]
 
+[tool.ruff.lint]
+select = ["I"]
+
 [tool.pyright]
 venvPath = "."
 venv = ".venv"

--- a/tests/params.py
+++ b/tests/params.py
@@ -19,6 +19,7 @@ class DataFileParam:
     expected_dtype: Optional[np.dtype] = None
     expected_length: Optional[int] = None
     expected_error: Optional[Type[BaseException]] = None
+    repeat_data: Optional[int] = None
     keep_type: bool = False
 
     def __post_init__(self):


### PR DESCRIPTION
Harp register data is commonly read from a file offline, but can also be batch loaded from in-memory buffers. This PR generalizes the device and register readers to expose a new `parse` method that works identical to `read` but receives any buffer-like object following [PEP 688](https://peps.python.org/pep-0688/).

This extends the library to be able to parse data from almost any source, including live streaming use cases.