### PR TITLE
Ensure datetime index when epoch is specified

### DIFF
--- a/harp/io.py
+++ b/harp/io.py
@@ -132,7 +132,12 @@ def _fromraw(
     keep_type: bool = False,
 ):
     if len(data) == 0:
-        return pd.DataFrame(columns=columns, index=pd.Index([], dtype=np.float64, name="Time"))
+        return pd.DataFrame(
+            columns=columns,
+            index=pd.DatetimeIndex([], name="Time")
+            if epoch
+            else pd.Index([], dtype=np.float64, name="Time"),
+        )
 
     if address is not None and address != data[2]:
         raise ValueError(f"expected address {address} but got {data[2]}")

--- a/tests/params.py
+++ b/tests/params.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from os import PathLike
 from pathlib import Path
 from typing import Iterable, Optional, Type, Union
@@ -20,6 +21,7 @@ class DataFileParam:
     expected_length: Optional[int] = None
     expected_error: Optional[Type[BaseException]] = None
     repeat_data: Optional[int] = None
+    epoch: Optional[datetime] = None
     keep_type: bool = False
 
     def __post_init__(self):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -32,6 +32,8 @@ testdata = [
     DataFileParam(path="data/write_0.bin", expected_address=0, expected_rows=4, keep_type=True),
     DataFileParam(path="data/device_0.bin", expected_rows=300, repeat_data=300),
     DataFileParam(path="data/device_0.bin", expected_rows=1, epoch=REFERENCE_EPOCH),
+    DataFileParam(path="data/empty_0.bin", expected_rows=0, epoch=REFERENCE_EPOCH),
+    DataFileParam(path="data/empty_0.bin", expected_rows=0),
 ]
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,10 +1,11 @@
 from contextlib import nullcontext
 
 import numpy as np
+import pandas as pd
 import pytest
 from pytest import mark
 
-from harp.io import MessageType, format, parse, read
+from harp.io import REFERENCE_EPOCH, MessageType, format, parse, read
 from tests.params import DataFileParam
 
 testdata = [
@@ -30,6 +31,7 @@ testdata = [
     DataFileParam(path="data/write_0.bin", expected_address=0, expected_rows=4),
     DataFileParam(path="data/write_0.bin", expected_address=0, expected_rows=4, keep_type=True),
     DataFileParam(path="data/device_0.bin", expected_rows=300, repeat_data=300),
+    DataFileParam(path="data/device_0.bin", expected_rows=1, epoch=REFERENCE_EPOCH),
 ]
 
 
@@ -46,6 +48,7 @@ def test_read(dataFile: DataFileParam):
                 address=dataFile.expected_address,
                 dtype=dataFile.expected_dtype,
                 length=dataFile.expected_length,
+                epoch=dataFile.epoch,
                 keep_type=dataFile.keep_type,
             )
         else:
@@ -54,9 +57,11 @@ def test_read(dataFile: DataFileParam):
                 address=dataFile.expected_address,
                 dtype=dataFile.expected_dtype,
                 length=dataFile.expected_length,
+                epoch=dataFile.epoch,
                 keep_type=dataFile.keep_type,
             )
         assert len(data) == dataFile.expected_rows
+        assert isinstance(data.index, pd.DatetimeIndex if dataFile.epoch else pd.Index)
         if dataFile.keep_type:
             assert MessageType.__name__ in data.columns and data[MessageType.__name__].dtype == "category"
 


### PR DESCRIPTION
When an `epoch` argument is specified on a call to `read` or `parse` the index of the resulting data frame should be of type `DatetimeIndex`, even if the data is empty.

Fixes #39 