### PR TITLE
Refactor IO API for consistency and symmetry

### DIFF
--- a/harp/__init__.py
+++ b/harp/__init__.py
@@ -1,5 +1,5 @@
-from harp.io import REFERENCE_EPOCH, MessageType, parse, read
+from harp.io import REFERENCE_EPOCH, MessageType, read
 from harp.reader import create_reader
 from harp.schema import read_schema
 
-__all__ = ["REFERENCE_EPOCH", "MessageType", "parse", "read", "create_reader", "read_schema"]
+__all__ = ["REFERENCE_EPOCH", "MessageType", "read", "create_reader", "read_schema"]

--- a/harp/__init__.py
+++ b/harp/__init__.py
@@ -1,5 +1,5 @@
-from harp.io import REFERENCE_EPOCH, MessageType, read
+from harp.io import REFERENCE_EPOCH, MessageType, read, to_buffer, to_file
 from harp.reader import create_reader
 from harp.schema import read_schema
 
-__all__ = ["REFERENCE_EPOCH", "MessageType", "read", "create_reader", "read_schema"]
+__all__ = ["REFERENCE_EPOCH", "MessageType", "read", "to_buffer", "to_file", "create_reader", "read_schema"]

--- a/harp/io.py
+++ b/harp/io.py
@@ -138,8 +138,8 @@ def read(
     return result
 
 
-def write(
-    file: Union[str, bytes, PathLike[Any], BinaryIO],
+def to_file(
+    file: _FileLike,
     data: pd.DataFrame,
     address: int,
     dtype: Optional[np.dtype] = None,
@@ -152,7 +152,7 @@ def write(
     Parameters
     ----------
     file
-        Open file object or filename where to store binary data from
+        File path, or open file object in which to store binary data from
         a single device register.
     data
         Pandas data frame containing message payload.
@@ -170,11 +170,11 @@ def write(
         Optional message type used for all formatted Harp messages.
         If not specified, data must contain a MessageType column.
     """
-    buffer = format(data, address, dtype, port, epoch, message_type)
+    buffer = to_buffer(data, address, dtype, port, epoch, message_type)
     buffer.tofile(file)
 
 
-def format(
+def to_buffer(
     data: pd.DataFrame,
     address: int,
     dtype: Optional[np.dtype] = None,
@@ -182,7 +182,7 @@ def format(
     epoch: Optional[datetime] = None,
     message_type: Optional[MessageType] = None,
 ) -> npt.NDArray[np.uint8]:
-    """Format single-register Harp data as a flat binary buffer.
+    """Convert single-register Harp data to a flat binary buffer.
 
     Parameters
     ----------

--- a/harp/io.py
+++ b/harp/io.py
@@ -219,9 +219,9 @@ def to_buffer(
     if nrows == 0:
         return np.empty(0, dtype=np.uint8)
 
-    if "MessageType" in data.columns:
-        msgtype = data["MessageType"].cat.codes
-        payload = data[data.columns.drop("MessageType")].values
+    if MessageType.__name__ in data.columns:
+        msgtype = data[MessageType.__name__].cat.codes
+        payload = data[data.columns.drop(MessageType.__name__)].values
     elif message_type is not None:
         msgtype = message_type
         payload = data.values

--- a/harp/typing.py
+++ b/harp/typing.py
@@ -1,10 +1,13 @@
 import mmap
 import sys
-from typing import Any, Union
+from os import PathLike
+from typing import Any, BinaryIO, Union
 
 from numpy.typing import NDArray
 
 if sys.version_info >= (3, 12):
-    from collections.abc import Buffer as BufferLike
+    from collections.abc import Buffer as _BufferLike
 else:
-    BufferLike = Union[bytes, bytearray, memoryview, mmap.mmap, NDArray[Any]]
+    _BufferLike = Union[bytes, bytearray, memoryview, mmap.mmap, NDArray[Any]]
+
+_FileLike = Union[str, PathLike[str], BinaryIO]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pytest import mark
 
-from harp.io import REFERENCE_EPOCH, MessageType, format, read
+from harp.io import REFERENCE_EPOCH, MessageType, read, to_buffer
 from tests.params import DataFileParam
 
 testdata = [
@@ -84,5 +84,5 @@ def test_write(dataFile: DataFileParam):
         keep_type=dataFile.keep_type,
     )
     assert len(data) == dataFile.expected_rows
-    write_buffer = format(data, address=dataFile.expected_address)
+    write_buffer = to_buffer(data, address=dataFile.expected_address)
     assert np.array_equal(buffer, write_buffer)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -84,5 +84,5 @@ def test_write(dataFile: DataFileParam):
         keep_type=dataFile.keep_type,
     )
     assert len(data) == dataFile.expected_rows
-    write_buffer = to_buffer(data, address=dataFile.expected_address)
+    write_buffer = to_buffer(data, address=dataFile.expected_address, length=dataFile.expected_length)
     assert np.array_equal(buffer, write_buffer)


### PR DESCRIPTION
Similar to other numeric and data frame processing libraries we would like to minimize the redundancy of functions exposed by the `io` module to avoid confusion.

Here we merge `read` and `parse` into a single `read` function accepting either a file-like or a buffer-like object. For consistency and symmetry, we also rename `write` and `format` as `to_file` and `to_buffer` functions, respectively.

Finally, the order of the first parameters into the `to_file` function has been swapped to match what would be more closely expected from an extension method.