### PR TITLE
Make `data` input to `_compose_parser` optional

### DIFF
--- a/harp/io.py
+++ b/harp/io.py
@@ -6,7 +6,7 @@ from typing import Any, BinaryIO, Optional, Union
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from pandas._typing import Axes
+from pandas._typing import Axes  # pyright: ignore[reportPrivateImportUsage]
 
 from harp.typing import _BufferLike, _FileLike
 

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -10,7 +10,7 @@ from typing import Callable, Iterable, Mapping, Optional, Protocol, Union
 
 from numpy import dtype
 from pandas import DataFrame, Series
-from pandas._typing import Axes
+from pandas._typing import Axes  # pyright: ignore[reportPrivateImportUsage]
 
 from harp.io import MessageType, read
 from harp.model import BitMask, GroupMask, Model, PayloadMember, Register

--- a/harp/reader.py
+++ b/harp/reader.py
@@ -82,7 +82,7 @@ def _compose_parser(
     params: _ReaderParams,
 ) -> Callable[..., DataFrame]:
     def parser(
-        data,
+        data: Optional[Union[_FileLike, _BufferLike]] = None,
         columns: Optional[Axes] = None,
         epoch: Optional[datetime] = params.epoch,
         keep_type: bool = params.keep_type,

--- a/tests/data/device.yml
+++ b/tests/data/device.yml
@@ -24,6 +24,22 @@ registers:
     length: 3
     access: Event
     description: Reports the current values of the analog input lines.
+  AnalogDataPayloadSpec:
+    address: 44
+    type: S16
+    length: 3
+    access: Event
+    description: Reports the current values of the analog input lines.
+    payloadSpec:
+      AnalogInput0:
+        offset: 0
+        description: The voltage at the output of the ADC channel 0.
+      Encoder:
+        offset: 1
+        description: The quadrature counter value on Port 2
+      AnalogInput1:
+        offset: 2
+        description: The voltage at the output of the ADC channel 1.
 bitMasks:
   DigitalInputs:
     description: Specifies the state of the digital input lines.

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -16,6 +16,11 @@ testdata = [
         expected_whoAmI=0,
         expected_registers=["AnalogData"],
     ),
+    DeviceSchemaParam(
+        path="data/device.yml",
+        expected_whoAmI=0,
+        expected_registers=["AnalogDataPayloadSpec"],
+    ),
 ]
 
 


### PR DESCRIPTION
Fixes an issue where the inner callable from ` _compose_parser` was not allowing the data input to be optional. 

https://github.com/harp-tech/harp-python/blob/9d05b584b9a16fe48fbbac89f2889b879a336ced/harp/reader.py#L79-L97

This allows `g` aka `_create_register_reader` to take care of the path inference logic

Closes #45