### PR TITLE
Favor yaml 1.1 spec via `pyyaml` package

### DIFF
--- a/harp/schema.py
+++ b/harp/schema.py
@@ -1,8 +1,8 @@
 from importlib import resources
 from os import PathLike
 from typing import TextIO, Union
-
-from pydantic_yaml import parse_yaml_raw_as
+from pydantic import TypeAdapter
+import yaml
 
 from harp.model import Model, Registers
 
@@ -13,7 +13,8 @@ def _read_common_registers() -> Registers:
 
     file = resources.files(__package__) / "common.yml"
     with file.open("r") as fileIO:
-        return parse_yaml_raw_as(Registers, fileIO.read())
+        raw_reg = yaml.safe_load(fileIO.read())
+        return TypeAdapter(Registers).validate_python(raw_reg)
 
 
 def read_schema(file: Union[str, PathLike, TextIO], include_common_registers: bool = True) -> Model:
@@ -37,7 +38,8 @@ def read_schema(file: Union[str, PathLike, TextIO], include_common_registers: bo
         with open(file) as fileIO:
             return read_schema(fileIO)
     else:
-        schema = parse_yaml_raw_as(Model, file.read())
+        raw_schema = yaml.safe_load(file.read())
+        schema = TypeAdapter(Model).validate_python(raw_schema)
         if "WhoAmI" not in schema.registers and include_common_registers:
             common = _read_common_registers()
             schema.registers = dict(common.registers, **schema.registers)

--- a/harp/schema.py
+++ b/harp/schema.py
@@ -1,8 +1,9 @@
 from importlib import resources
 from os import PathLike
 from typing import TextIO, Union
-from pydantic import TypeAdapter
+
 import yaml
+from pydantic import TypeAdapter
 
 from harp.model import Model, Registers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ dynamic = ["version"]
 license = "MIT"
 
 dependencies = [
-    "pydantic-yaml",
+    "pydantic",
+    "pyyaml",
     "pandas"
 ]
 


### PR DESCRIPTION
This PR simplifiest the dependencies of this library by dropping `pydantic-yaml`. This has two advantages:
1- We now only rely on pydantic and pyyaml, two well supported and maintained pacakges
2- We support 1.1 by default. This is important as pyyaml officialy targets version 1.1 of the yaml spec. This is the version we have classically been using to make new devices.

It should be noted that this PR is blocked by https://github.com/harp-tech/protocol/issues/159 and the respective reference to a new `device.yml` file. This should probably be done via submodule.